### PR TITLE
Add possibility to set absolute achievement progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ func _on_achievement_incremented(achievement: String):
 func _on_achievement_incrementing_failed(achievement: String):
 	pass
 ```
+##### Set Achievement Steps
+```gdscript
+var steps = 3
+play_games_services.setAchievementSteps("ACHIEVEMENT_ID", steps)
+
+# Callbacks:
+func _on_achievement_steps_set(achievement: String):
+	pass
+
+func _on_achievement_steps_setting_failed(achievement: String):
+	pass
+```
 ##### Reveal Achievement
 ```gdscript
 play_games_services.revealAchievement("ACHIEVEMENT_ID")

--- a/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
@@ -53,6 +53,9 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
         val SIGNAL_ACHIEVEMENT_INCREMENTED = SignalInfo("_on_achievement_incremented", String::class.java)
         val SIGNAL_ACHIEVEMENT_INCREMENTED_FAILED =
             SignalInfo("_on_achievement_incrementing_failed", String::class.java)
+        val SIGNAL_ACHIEVEMENT_STEPS_SET = SignalInfo("_on_achievement_steps_set", String::class.java)
+        val SIGNAL_ACHIEVEMENT_STEPS_SET_FAILED =
+            SignalInfo("_on_achievement_steps_setting_failed", String::class.java)
         val SIGNAL_LEADERBOARD_SCORE_SUBMITTED = SignalInfo("_on_leaderboard_score_submitted", String::class.java)
         val SIGNAL_LEADERBOARD_SCORE_SUBMITTED_FAILED =
             SignalInfo("_on_leaderboard_score_submitting_failed", String::class.java)
@@ -84,6 +87,7 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
             "unlockAchievement",
             "revealAchievement",
             "incrementAchievement",
+            "setAchievementSteps",
             "showLeaderBoard",
             "showAllLeaderBoards",
             "submitLeaderBoardScore",
@@ -109,6 +113,8 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
             SIGNAL_ACHIEVEMENT_REVEALED_FAILED,
             SIGNAL_ACHIEVEMENT_INCREMENTED,
             SIGNAL_ACHIEVEMENT_INCREMENTED_FAILED,
+            SIGNAL_ACHIEVEMENT_STEPS_SET,
+            SIGNAL_ACHIEVEMENT_STEPS_SET_FAILED,
             SIGNAL_LEADERBOARD_SCORE_SUBMITTED,
             SIGNAL_LEADERBOARD_SCORE_SUBMITTED_FAILED,
             SIGNAL_EVENT_SUBMITTED,
@@ -213,6 +219,12 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
         }
     }
 
+    fun setAchievementSteps(achievementName: String, steps: Int) {
+        runOnUiThread {
+            achievementsController.setAchievementSteps(achievementName, steps)
+        }
+    }
+
     fun showLeaderBoard(leaderBoardId: String) {
         runOnUiThread {
             leaderboardsController.showLeaderboard(leaderBoardId)
@@ -295,6 +307,14 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
 
     override fun onAchievementIncrementingFailed(achievementName: String) {
         emitSignal(SIGNAL_ACHIEVEMENT_INCREMENTED_FAILED.name, achievementName)
+    }
+
+    override fun onAchievementStepsSet(achievementName: String) {
+        emitSignal(SIGNAL_ACHIEVEMENT_STEPS_SET.name, achievementName)
+    }
+
+    override fun onAchievementStepsSettingFailed(achievementName: String) {
+        emitSignal(SIGNAL_ACHIEVEMENT_STEPS_SET_FAILED.name, achievementName)
     }
 
     override fun onEventSubmitted(eventId: String) {

--- a/app/src/main/java/io/cgisca/godot/gpgs/achievements/AchievementsController.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/achievements/AchievementsController.kt
@@ -45,6 +45,16 @@ class AchievementsController(
         }
     }
 
+    fun setAchievementSteps(achievementName: String, steps: Int) {
+        val googleSignInAccount = GoogleSignIn.getLastSignedInAccount(activity)
+        if (connectionController.isConnected().first && googleSignInAccount != null) {
+            Games.getAchievementsClient(activity, googleSignInAccount).setSteps(achievementName, steps)
+            achievementsListener.onAchievementStepsSet(achievementName)
+        } else {
+            achievementsListener.onAchievementStepsSettingFailed(achievementName)
+        }
+    }
+
     fun showAchievements() {
         val googleSignInAccount = GoogleSignIn.getLastSignedInAccount(activity)
         if (connectionController.isConnected().first && googleSignInAccount != null) {

--- a/app/src/main/java/io/cgisca/godot/gpgs/achievements/AchievementsListener.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/achievements/AchievementsListener.kt
@@ -7,4 +7,6 @@ interface AchievementsListener {
     fun onAchievementRevealingFailed(achievementName: String)
     fun onAchievementIncremented(achievementName: String)
     fun onAchievementIncrementingFailed(achievementName: String)
+    fun onAchievementStepsSet(achievementName: String)
+    fun onAchievementStepsSettingFailed(achievementName: String)
 }

--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -4,6 +4,7 @@ extends Control
 const UNLOCK_ACHIEVEMENT = "CgkIqt-jg_MWEAIQAQ"
 const REVEAL_ACHIEVEMENT = "CgkIqt-jg_MWEAIQAQ"
 const INCREMENT_ACHIEVEMENT = "CgkIqt-jg_MWEAIQAQ"
+const SET_ACHIEVEMENT_STEPS = "CgkIqt-jg_MWEAIQAQ"
 const LEADERBOARD_ID = "CgkIqt-jg_MWEAIQAQ"
 
 var play_games_services
@@ -23,6 +24,8 @@ func _ready():
 		play_games_services.connect("_on_achievement_revealing_failed", self, "_on_achievement_revealing_failed")
 		play_games_services.connect("_on_achievement_incremented", self, "_on_achievement_incremented")
 		play_games_services.connect("_on_achievement_incrementing_failed", self, "_on_achievement_incrementing_failed")
+		play_games_services.connect("_on_achievement_steps_set", self, "_on_achievement_steps_set")
+		play_games_services.connect("_on_achievement_steps_setting_failed", self, "_on_achievement_steps_setting_failed")
 		play_games_services.connect("_on_leaderboard_score_submitted", self, "_on_leaderboard_score_submitted")
 		play_games_services.connect("_on_leaderboard_score_submitting_failed", self, "_on_leaderboard_score_submitting_failed")
 		play_games_services.connect("_on_game_saved_success", self, "_on_game_saved_success")
@@ -61,6 +64,12 @@ func increment_achievement() -> void:
 	if play_games_services:
 		var step = 2
 		play_games_services.incrementAchievement(INCREMENT_ACHIEVEMENT, step) 
+
+
+func set_achievement_steps() -> void:
+	if play_games_services:
+		var steps = 5
+		play_games_services.setAchievementsSteps(SET_ACHIEVEMENT_STEPS, steps
 
 
 func show_achievements() -> void:
@@ -135,6 +144,12 @@ func _on_achievement_incremented(achievement: String) -> void:
 
 func _on_achievement_incrementing_failed(achievement: String) -> void:
 	print("Achievement %s incrementing failed"%achievement)
+
+func _on_achievement_steps_set(achievement: String) -> void:
+	print("Achievement %s steps set"%achievement)
+
+func _on_achievement_steps_setting_failed(achievement: String) -> void:
+	print("Achievement %s steps setting failed"%achievement)
 
 
 # Leaderboards callbacks


### PR DESCRIPTION
This is useful to avoid having to track the current value. It also makes easier having a common API in your game that wraps both this and the iOS Game Center integration, which doesn't have an increment method.

I take the opportunity to thank you for this project! It's excellent, very well done and has saved me a lot of time.