### PR TITLE
Add possibility to check current logged in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ func _on_sign_out_success():
 func _on_sign_out_failed():
 	pass
 ```
+##### Check if signed in
+```gdscript
+var is_signed_in: boole = play_games_services.isSignedIn()
+```
 #### Achievements
 ##### Unlock Achievement
 ```gdscript

--- a/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
@@ -25,6 +25,8 @@ import org.godotengine.godot.Godot
 import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.plugin.SignalInfo
 import java.math.BigInteger
+import java.util.concurrent.Callable
+import java.util.concurrent.FutureTask
 import java.util.Random
 
 class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsListener, EventsListener,
@@ -83,6 +85,7 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
             "initWithSavedGames",
             "signIn",
             "signOut",
+            "isSignedIn",
             "showAchievements",
             "unlockAchievement",
             "revealAchievement",
@@ -194,6 +197,9 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
             signInController.signOut(googleSignInClient)
         }
     }
+
+    fun isSignedIn(): Boolean {
+        return signInController.isSignedIn()
 
     fun showAchievements() {
         runOnUiThread {

--- a/app/src/main/java/io/cgisca/godot/gpgs/signin/SignInController.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/signin/SignInController.kt
@@ -78,6 +78,11 @@ class SignInController(
         }
     }
 
+    fun isSignedIn(): Boolean {
+        val googleSignInAccount = GoogleSignIn.getLastSignedInAccount(activity)
+        return connectionController.isConnected().first && googleSignInAccount != null
+    }
+
     private fun enablePopUps() {
         if (showPlayPopups) {
             val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(activity)

--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -49,6 +49,12 @@ func sign_out() -> void:
 		play_games_services.signOut()
 
 
+func check_if_signed_in() -> void:
+	if play_games_services:
+		var is_signed_in: bool = play_games_services.isSignedIn()
+		print("Signed in: %s"%is_signed_in)	
+
+
 # Achievements methods
 func unlock_achievement() -> void:
 	if play_games_services:
@@ -188,6 +194,10 @@ func _on_SignInButton_pressed():
 func _on_SignOutButton_pressed():
 	sign_out()
 
+
+func _on_CheckIfSignedInButton_pressed():
+	check_if_signed_in()
+	
 
 func _on_SaveGameButton_pressed():
 	save_game()

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -32,42 +32,50 @@ margin_bottom = 240.0
 rect_min_size = Vector2( 200, 100 )
 text = "Sign Out"
 
-[node name="SaveGameButton" type="Button" parent="VBoxContainer"]
+[node name="CheckIfSignedInButton" type="Button" parent="VBoxContainer"]
 margin_top = 280.0
 margin_right = 600.0
 margin_bottom = 380.0
 rect_min_size = Vector2( 200, 100 )
-text = "Save game"
+text = "Check If Signed In"
 
-[node name="ShowSavedGamesButton" type="Button" parent="VBoxContainer"]
+[node name="SaveGameButton" type="Button" parent="VBoxContainer"]
 margin_top = 420.0
 margin_right = 600.0
 margin_bottom = 520.0
 rect_min_size = Vector2( 200, 100 )
-text = "ShowSavedGames"
+text = "Save game"
 
-[node name="Button" type="Button" parent="VBoxContainer"]
+[node name="ShowSavedGamesButton" type="Button" parent="VBoxContainer"]
 margin_top = 560.0
 margin_right = 600.0
 margin_bottom = 660.0
 rect_min_size = Vector2( 200, 100 )
-text = "Load saved game"
+text = "ShowSavedGames"
 
-[node name="ShowLeaderBoardsButton" type="Button" parent="VBoxContainer"]
+[node name="Button" type="Button" parent="VBoxContainer"]
 margin_top = 700.0
 margin_right = 600.0
 margin_bottom = 800.0
-rect_min_size = Vector2( 0, 100 )
-text = "Show leaderboards"
+rect_min_size = Vector2( 200, 100 )
+text = "Load saved game"
 
-[node name="AchievementUnlockButton" type="Button" parent="VBoxContainer"]
+[node name="ShowLeaderBoardsButton" type="Button" parent="VBoxContainer"]
 margin_top = 840.0
 margin_right = 600.0
 margin_bottom = 940.0
 rect_min_size = Vector2( 0, 100 )
+text = "Show leaderboards"
+
+[node name="AchievementUnlockButton" type="Button" parent="VBoxContainer"]
+margin_top = 980.0
+margin_right = 600.0
+margin_bottom = 1080.0
+rect_min_size = Vector2( 0, 100 )
 text = "Unlock achievement"
 [connection signal="pressed" from="VBoxContainer/SignInButton" to="." method="_on_SignInButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/SignOutButton" to="." method="_on_SignOutButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/CheckIfSignedInButton" to="." method="_on_CheckIfSignedInButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/SaveGameButton" to="." method="_on_SaveGameButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/ShowSavedGamesButton" to="." method="_on_ShowSavedGamesButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/Button" to="." method="_on_Button_pressed"]


### PR DESCRIPTION
I think the old version of this plugin already had something similar.

Since there's no way for the Google auth API to notify that the user has logged out (unless they has initiated the sign out explicitly), a game has no way to easily check if the user has logged out. For instance, say the user opens the achievements UI and logs out from there.

One option would be handle the failed callback of the next action, but this is much more ergonomic. A game can use it in the `NOTIFICATION_WM_FOCUS_IN` to check if the user has somehow logged out while the game wasn't in the foreground.