### PR TITLE
add method to check if google services are available on device

### DIFF
--- a/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
@@ -2,6 +2,8 @@ package io.cgisca.godot.gpgs
 
 import android.app.Activity
 import android.content.Intent
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.auth.api.Auth
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -86,6 +88,7 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
 
     override fun getPluginMethods(): MutableList<String> {
         return mutableListOf(
+            "isGooglePlayServicesAvailable",
             "init",
             "initWithSavedGames",
             "signIn",
@@ -162,6 +165,11 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
                 }
             }
         }
+    }
+
+    fun isGooglePlayServicesAvailable() : Boolean {
+        val result: Int = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(godot as Activity)
+        return result == ConnectionResult.SUCCESS
     }
 
     fun init(enablePopups: Boolean) {


### PR DESCRIPTION
Devices that don't have Google services installed will show an error when the module's `init()` method is called. This pull request adds a method `isGooglePlayServicesAvailable()` to check if compatible Google services are installed, so that developers can gracefully account for devices that don't have them before calling `init()`.